### PR TITLE
Add root Gradle setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "RoadAndCameraMap"
+include(":app")


### PR DESCRIPTION
## Summary
- add a basic `settings.gradle` for Gradle project name and module include
- add a root `build.gradle` specifying repositories and classpaths

## Testing
- `gradle tasks --all` *(fails: Namespace not specified)*
- `gradle help` *(fails: Namespace not specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877eaa286d8832484a83b85baff9e2b